### PR TITLE
修改 mobile:user-agent,使得登陆页面为手机版非桌面版

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 	<div id="wrapper">
 
 		<!-- webview -->
-	    <webview id="wv" src="http://m.bilibili.com/index.html" useragent="bilimini Mobile like (iPhone or Android) whatever" preload="./js/inject.js"></webview>
+	    <webview id="wv" src="http://m.bilibili.com/index.html" useragent="Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3" preload="./js/inject.js"></webview>
 
 		<!-- loading -->
 		<div id="loading"></div>

--- a/js/index.js
+++ b/js/index.js
@@ -5,7 +5,7 @@ const shell = require('electron').shell;
 const appData = require('./package.json');
 const userAgent = {
     desktop: 'bilimini Desktop like Mozilla/233 (Chrome and Safari)',
-    mobile: 'bilimini Mobile like (iPhone or Android) whatever'
+    mobile: 'Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3'
 };
 const videoUrlPrefix = 'http://bilibili.com/video/av';
 const videoUrlPattern = /video\/av(\d+(?:\/index_\d+\.html)?(?:\/#page=\d+)?)/;


### PR DESCRIPTION
`Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3`
修改 mobile:user-agent,使得登陆页面为手机版非桌面版,后退功能也可以正常返回手机页面

<img width="375" alt="qq20170525-141043 2x" src="https://cloud.githubusercontent.com/assets/2404478/26449700/f9a2f1da-4153-11e7-8bde-ef6578835c07.png">


