### PR TITLE
修复弹幕开关及增加全局默认字体

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.log
 /package-lock.json
 *.txt
+.DS_Store

--- a/js/index.js
+++ b/js/index.js
@@ -274,14 +274,16 @@ const v = new Vue({
         return false;
       }
       utils.log('主窗口：点击弹幕开关');
-      wv.executeJavaScript(`document.getElementsByName('ctlbar_danmuku_on').length`, function(result) {
-        let isDanmakuOn = result == 1;
-        if(isDanmakuOn) {
-          wv.executeJavaScript(`document.querySelector('.bilibili-player-iconfont-danmaku-off').click()`)
-        } else {
-          wv.executeJavaScript(`document.querySelector('.bilibili-player-iconfont-danmaku').click()`)
-        }
-      });
+      // 2018-12-05 适配最新B站弹幕开关
+      wv.executeJavaScript(`document.querySelector('.bilibili-player-video-danmaku-switch .bui-checkbox').click()`)
+      // wv.executeJavaScript(`document.getElementsByName('ctlbar_danmuku_on').length`, function(result) {
+      //   let isDanmakuOn = result == 1;
+      //   if(isDanmakuOn) {
+      //     wv.executeJavaScript(`document.querySelector('.bilibili-player-iconfont-danmaku-off').click()`)
+      //   } else {
+      //     wv.executeJavaScript(`document.querySelector('.bilibili-player-iconfont-danmaku').click()`)
+      //   }
+      // });
     }
   }
 });

--- a/js/inject.js
+++ b/js/inject.js
@@ -1,6 +1,11 @@
 const ipc = require('electron').ipcRenderer;
 
 window.addEventListener('DOMContentLoaded', function() {
+  // 默认字体设置
+  let fontFamilyCss = document.createElement('style');
+  fontFamilyCss.type = 'text/css';
+  fontFamilyCss.innerHTML = "html{font-family:'Helvetica Neue', Helvetica, 'Hiragino Sans GB', 'Segoe UI', 'Microsoft Yahei', Tahoma, Arial, STHeiti, sans-serif}"
+  document.head.appendChild(fontFamilyCss);
 
   // 首页、分区首页支持多列
   if( /bilibili\.com\/index\.html$/.test(window.location.href) || /\/channel\/\d+\.html$/.test(window.location.href) ) {


### PR DESCRIPTION
修复弹幕开关

mac上启动, 当前版本(v1.1.7)默认字体效果
![default](https://user-images.githubusercontent.com/13271070/49508536-ef2cd400-f8bd-11e8-8956-9ff2f8617add.png)
增加全局默认字体后
![default](https://user-images.githubusercontent.com/13271070/49508607-15527400-f8be-11e8-8908-a7d2d1c92da8.png)


